### PR TITLE
Avoid recreating anchors

### DIFF
--- a/src/main/scala/com/ccm/me/playground/bindingscala/calc/ui.scala
+++ b/src/main/scala/com/ccm/me/playground/bindingscala/calc/ui.scala
@@ -139,10 +139,9 @@ class ui extends ShowCase {
       case "MS" => ("green lighten-5 green-text", MS())
       case _ => ("", NoOp())
     }
-    val c = calc.bind
-    val disabled = if (c.isDefinedAt(op._2)) "" else "disabled"
-    <a class={s"btn ${op._1} ${disabled} waves-effect waves-light"}
-       onclick={_: Event => calc.value = c(op._2)}>
+    def disabled = Binding { if (calc.bind.isDefinedAt(op._2)) "" else "disabled" }
+    <a class={s"btn ${op._1} ${disabled.bind} waves-effect waves-light"}
+       onclick={_: Event => calc.value = calc.value(op._2)}>
       {label}
     </a>
   }


### PR DESCRIPTION
According to the [Scaladoc of Binding.scala](https://javadoc.io/page/com.thoughtworks.binding/binding_2.12/latest/com/thoughtworks/binding/Binding.html#bind:A):

> Each time the value changes, in the current `@dom` method, all code after the current `bind` expression will be re-evaluated

As a result, the `calc.bind` call forces recreating the anchor element.

This PR changes the `class` attribute instead.